### PR TITLE
mistake in __call__() in NChooseK

### DIFF
--- a/opti/constraint.py
+++ b/opti/constraint.py
@@ -278,7 +278,7 @@ class NChooseK(Constraint):
         self.is_equality = False
 
     def __call__(self, data: pd.DataFrame) -> pd.Series:
-        x = data[self.names].values
+        x = np.abs(data[self.names].values)
         num_zeros = x.shape[1] - self.max_active
         violation = np.apply_along_axis(
             func1d=lambda r: sum(sorted(r)[:num_zeros]), axis=1, arr=x


### PR DESCRIPTION
I think one has to take the absolute of the input data, otherwise examples like the following would satisfy the constraint (if the smallest N-K values add up to 0)

data = pd.DataFrame([[-0.5,0.5,1]], columns=["x1","x2","x3"])
c = NChooseK(["x1", "x2", "x3"], 1)
c.satisfied(data)